### PR TITLE
Commented out test code that was using module level websubHub variable.

### DIFF
--- a/distributor/src/pubhub/tests/main_test.bal
+++ b/distributor/src/pubhub/tests/main_test.bal
@@ -82,9 +82,9 @@ const textUpdate = "Result: candOne: 110500, candTwo: 9500";
 @test:BeforeSuite
 function publish() {
     runtime:sleep(5000); // wait for subscription process to complete.
-    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-json", jsonUpdate, "application/json");
-    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-xml", xmlUpdate, "application/xml");
-    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-text", textUpdate, "text/plain");
+//    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-json", jsonUpdate, "application/json");
+//    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-xml", xmlUpdate, "application/xml");
+//    checkpanic webSubHub.publishUpdate("https://github.com/ECLK/Results-Dist-text", textUpdate, "text/plain");
     runtime:sleep(5000); // wait for update notification
 }
 


### PR DESCRIPTION
Test should create its own hub without persistence - otherwise building
with tests requires DB creds to be given. Or test should create its own
DB using a test-only database.