### PR TITLE
Limit request payload max size to 4mb

### DIFF
--- a/distributor/src/distributor/listeners.bal
+++ b/distributor/src/distributor/listeners.bal
@@ -3,7 +3,11 @@ import ballerina/config;
 import ballerina/http;
 
 # Listener for results tabulation to deliver results to us.
-listener http:Listener resultsListener = new (config:getAsInt("eclk.pub.port", 8181));
+listener http:Listener resultsListener = new (config:getAsInt("eclk.pub.port", 8181), {
+    http1Settings: {
+        maxEntityBodySize: 4194304
+    }
+});
 
 http:BasicAuthHandler inboundBasicAuthHandler = new (new auth:InboundBasicAuthProvider());
 


### PR DESCRIPTION
> Maximum allowed size for the entity body is 4mb. On the Exceeding this limit will result in a `413 - Payload Too Large` response.