### PR TITLE
Fix image store, switch to new result types, and other minor fixes

### DIFF
--- a/distributor/Dockerfile
+++ b/distributor/Dockerfile
@@ -19,4 +19,4 @@ COPY  --from=build /usr/src/target /usr/src/target
 WORKDIR /usr/src/
 ADD ./web web
 
-CMD java -jar target/bin/distributor.jar --eclk.hub.db.url=jdbc:mysql://$DB_URL --eclk.hub.db.username=$DB_UN --eclk.hub.db.password=$DB_PW --eclk.hub.db.useSsl=$DB_USE_SSL --eclk.hub.db.encryptionkey=$DB_ENCRYPTION_KEY --eclk.govsms.username=$SMS_USER  --eclk.govsms.password=$SMS_PASSWORD --eclk.govsms.source=$SMS_SOURCE
+CMD java -jar target/bin/distributor.jar --eclk.distributor.db.url=jdbc:mysql://$DB_URL --eclk.distributor.db.username=$DB_UN --eclk.distributor.db.password=$DB_PW --eclk.distributor.db.useSsl=$DB_USE_SSL --eclk.govsms.username=$SMS_USER  --eclk.govsms.password=$SMS_PASSWORD --eclk.govsms.source=$SMS_SOURCE

--- a/distributor/src/distributor/constants.bal
+++ b/distributor/src/distributor/constants.bal
@@ -2,3 +2,13 @@ const ERROR_REASON = "{eclk/distributor}Error";
 
 const ELECTION_TYPE_PRESIDENTIAL = "PRESIDENTIAL";
 const ELECTION_TYPE_PARLIAMENTARY = "PARLIAMENTARY";
+
+const RP_V = "RP_V";
+const RE_VI = "RE_VI";
+const RE_S = "RE_S";
+const RN_SI = "RN_SI";
+const RN_VS = "RN_VS";
+const RN_VSN = "RN_VSN";
+const RE_SC = "RE_SC";
+const RN_NC = "RN_NC";
+const RN_SCNC = "RN_SCNC";

--- a/distributor/src/distributor/constants.bal
+++ b/distributor/src/distributor/constants.bal
@@ -1,4 +1,4 @@
-const ERROR_REASON = "{eclk/pubhub}Error";
+const ERROR_REASON = "{eclk/distributor}Error";
 
 const ELECTION_TYPE_PRESIDENTIAL = "PRESIDENTIAL";
 const ELECTION_TYPE_PARLIAMENTARY = "PARLIAMENTARY";

--- a/distributor/src/distributor/genhtml.bal
+++ b/distributor/src/distributor/genhtml.bal
@@ -112,13 +112,14 @@ function sortParliamentaryByPartyResults(json[] unsorted, string resultType) ret
     }
 
     match resultType {
-        "R_NC"|"R_SCNC" => {
+        RN_NC|RN_SCNC => {
             return unsorted;
         }
-        "R_SI" => {
+        RN_SI => {
             return sortByPartyResultsBySeatCount(unsorted);
         }
     }
+    // RN_VS, RN_VSN
     return sortByPartyResultsByVoteCount(unsorted);
 }
 

--- a/distributor/src/distributor/listeners.bal
+++ b/distributor/src/distributor/listeners.bal
@@ -12,7 +12,7 @@ listener http:Listener resultsListener = new (config:getAsInt("eclk.pub.port", 8
 http:BasicAuthHandler inboundBasicAuthHandler = new (new auth:InboundBasicAuthProvider());
 
 # Listener for media orgs to subscribe, for the website and for them to pull specific results.
-listener http:Listener mediaListener = new (config:getAsInt("eclk.hub.port", 9090), config = {
+listener http:Listener mediaListener = new (config:getAsInt("eclk.distributor.port", 9090), config = {
     auth: {
         authHandlers: [inboundBasicAuthHandler],
         position: 1,

--- a/distributor/src/distributor/messenger.bal
+++ b/distributor/src/distributor/messenger.bal
@@ -30,8 +30,6 @@ function getAwaitResultsMessage(string electionCode, string resultType, string r
                 pdLevelName = "POSTAL";
             } else if (resultCode.endsWith("DV")) {
                 pdLevelName = "DISPLACED";
-            } else if (resultCode.endsWith("QV")) {
-                pdLevelName = "QUARANTINE";
             } else {
                 pdLevelName = "POLLING-DIVISION";
             }
@@ -42,6 +40,9 @@ function getAwaitResultsMessage(string electionCode, string resultType, string r
             string electoralDistrict = "/" + (ed_name ?: "<unknown electoral district>");
 
             message  = "Await ELECTORAL-DISTRICT results for " + electionCode + resultType + electoralDistrict;
+        }
+        LEVEL_N => {
+            message  = "Await NATIONAL results for " + electionCode + resultType;
         }
         LEVEL_NF => {
             message  = "Await NATIONAL-FINAL results for " + electionCode + resultType;

--- a/distributor/src/distributor/results.bal
+++ b/distributor/src/distributor/results.bal
@@ -139,7 +139,7 @@ service receiveResults on resultsListener {
 function publishResultData(Result result, string? electionCode = (), string? resultCode = ()) {
     map<json> jsonResult = result.jsonResult;
 
-    if jsonResult.level == "NATIONAL" && !(jsonResult.by_party is error) {
+    if jsonResult.level == LEVEL_N && !(jsonResult.by_party is error) {
         jsonResult["by_party"] = byPartySortFunction(<json[]> jsonResult.by_party, result.'type);
     }
 
@@ -273,10 +273,10 @@ function sendPresidentialIncrementalResult(CumulativeResult resCumResult, string
 function sendParliamentaryIncrementalResult(CumulativeResult resCumResult, string electionCode, string resultType,
                                             string resultCode, Result result) returns error? {
     if resCumResult is ParliamentaryCumulativeVotesResult {
-        return sendParliamentaryIncrementalVotesResult(resCumResult, electionCode, "R_VI", resultCode, result);
+        return sendParliamentaryIncrementalVotesResult(resCumResult, electionCode, RE_VI, resultCode, result);
     }
 
-    return sendParliamentaryIncrementalSeatsResult(resCumResult, electionCode, "R_SI", resultCode, result);
+    return sendParliamentaryIncrementalSeatsResult(resCumResult, electionCode, RN_SI, resultCode, result);
 }
 
 function sendParliamentaryIncrementalVotesResult(CumulativeResult resCumResult, string electionCode, string resultType,

--- a/distributor/src/distributor/results.bal
+++ b/distributor/src/distributor/results.bal
@@ -93,18 +93,18 @@ service receiveResults on resultsListener {
 
     @http:ResourceConfig {
         methods: ["POST"],
-        path: "/image/{electionCode}/{resultCode}",
+        path: "/image/{electionCode}/{resultType}/{resultCode}",
         body: "imageData"
     }
-    resource function receiveImage(http:Caller caller, http:Request req, string electionCode, string resultCode, 
-                                   byte[] imageData) returns error? {
-        log:printInfo("Result image received for " + electionCode +  "/" + resultCode);
+    resource function receiveImage(http:Caller caller, http:Request req, string electionCode, string resultType, 
+                                   string resultCode, byte[] imageData) returns error? {
+        log:printInfo("Result image received for " + electionCode +  "/" + resultType + "/" + resultCode);
 
         string mediaType = req.getContentType();
 
         // store the image in the DB against the resultCode and retrieve the relevant result
-        Result? res = check saveImage(<@untainted> electionCode, <@untainted> resultCode, <@untainted> mediaType,
-                                      <@untainted> imageData);
+        Result? res = check saveImage(<@untainted> electionCode, <@untainted> resultType, <@untainted> resultCode, 
+                                      <@untainted> mediaType, <@untainted> imageData);
 
         if (res is Result) {
             int sequenceNo = <int> res.sequenceNo;

--- a/distributor/src/distributor/save.bal
+++ b/distributor/src/distributor/save.bal
@@ -345,7 +345,7 @@ function addToParliamentaryCumulative(map<json> jm)
 }
 
 function addToParliamentaryCumulativeVotes(map<json> jm) returns ParliamentaryCumulativeVotesResult? {
-    if jm.'type != "R_V" {
+    if jm.'type != RP_V {
         return;
     }
 
@@ -396,7 +396,7 @@ function getMatchingByPartyRecord(ParliamentaryPartyResult[] partyResultArray, s
 }
 
 function addToParliamentaryCumulativeSeats(map<json> jm) returns ParliamentaryCumulativeSeatsResult? {
-    if jm.'type != "R_S" {
+    if jm.'type != RE_S {
         return;
     }
 

--- a/distributor/src/distributor/save.bal
+++ b/distributor/src/distributor/save.bal
@@ -48,11 +48,11 @@ const DROP_RECIPIENT_TABLE = "DROP TABLE smsRecipients";
 const DELETE_RECIPIENT_TABLE = "DELETE FROM smsRecipients";
 
 jdbc:Client dbClient = new ({
-    url: config:getAsString("eclk.hub.db.url"),
-    username: config:getAsString("eclk.hub.db.username"),
-    password: config:getAsString("eclk.hub.db.password"),
+    url: config:getAsString("eclk.distributor.db.url"),
+    username: config:getAsString("eclk.distributor.db.username"),
+    password: config:getAsString("eclk.distributor.db.password"),
     dbOptions: {
-        useSSL: config:getAsString("eclk.hub.db.useSsl")
+        useSSL: config:getAsString("eclk.distributor.db.useSsl")
     }    
 });
 

--- a/distributor/src/distributor/save.bal
+++ b/distributor/src/distributor/save.bal
@@ -33,7 +33,8 @@ const string CREATE_RESULTS_TABLE = "CREATE TABLE IF NOT EXISTS results (" +
                                     "    PRIMARY KEY (sequenceNo))";
 const INSERT_RESULT = "INSERT INTO results (election, code, jsonResult, type) VALUES (?, ?, ?, ?)";
 const UPDATE_RESULT_JSON = "UPDATE results SET jsonResult = ? WHERE sequenceNo = ?";
-const UPDATE_RESULT_IMAGE = "UPDATE results SET imageMediaType = ?, imageData = ? WHERE election = ? AND code = ?";
+const string UPDATE_RESULT_IMAGE = "UPDATE results SET imageMediaType = ?, imageData = ? WHERE election = ? " + 
+                                "AND type = ? AND code = ?";
 const SELECT_RESULTS_DATA = "SELECT sequenceNo, election, code, type, jsonResult, imageMediaType, imageData FROM results";
 const DROP_RESULTS_TABLE = "DROP TABLE results";
 
@@ -226,9 +227,10 @@ function saveResult(Result result) returns CumulativeResult|error? {
 
 # Save an image associated with a result
 # + return - error if unable to insert image for the given resultCode
-function saveImage(string electionCode, string resultCode, string mediaType, byte[] imageData) returns Result|error? {
+function saveImage(string electionCode, string resultType, string resultCode, string mediaType, 
+                   byte[] imageData) returns Result|error? {
     // save in DB
-    var ret = dbClient->update(UPDATE_RESULT_IMAGE, mediaType, imageData, electionCode, resultCode);
+    var ret = dbClient->update(UPDATE_RESULT_IMAGE, mediaType, imageData, electionCode, resultType, resultCode);
     if ret is jdbc:DatabaseError {
         log:printError("Unable to save image in database: " + ret.toString());
         return ret;
@@ -238,7 +240,7 @@ function saveImage(string electionCode, string resultCode, string mediaType, byt
     boolean updated = false;
     Result? res = ();
     foreach Result r in resultsCache {
-        if r.election == electionCode && r.code == resultCode {
+        if r.election == electionCode && r.'type == resultType && r.code == resultCode {
             r.imageMediaType = mediaType;
             r.imageData = imageData;
             res = r;
@@ -248,8 +250,8 @@ function saveImage(string electionCode, string resultCode, string mediaType, byt
     }
     if !updated {
         // shouldn't happen .. but don't want to panic and die either
-        log:printWarn("Updating result cache for new image for election=" + electionCode + ", code='" + resultCode +
-                      "' failed as result was missing. WEIRD!");
+        log:printWarn("Updating result cache for new image for election='" + electionCode + 
+                      "', type='" + resultType + "', code='" + resultCode + "' failed as result was missing. WEIRD!");
     }
 
     return res;

--- a/distributor/src/distributor/website.bal
+++ b/distributor/src/distributor/website.bal
@@ -8,7 +8,8 @@ import ballerina/xmlutils;
 const LEVEL_PD = "POLLING-DIVISION";
 const LEVEL_ED = "ELECTORAL-DISTRICT";
 const LEVEL_NI = "NATIONAL-INCREMENTAL";
-const LEVEL_NF = "NATIONAL";
+const LEVEL_N = "NATIONAL";
+const LEVEL_NF = "NATIONAL-FINAL";
 
 const WANT_IMAGE = "image";
 const WANT_AWAIT_RESULTS = "await";

--- a/subscriber/src/subscriber/save.bal
+++ b/subscriber/src/subscriber/save.bal
@@ -9,7 +9,8 @@ const PRESIDENTIAL_RESULT = "PRESIDENTIAL-FIRST";
 const LEVEL_PD = "POLLING-DIVISION";
 const LEVEL_ED = "ELECTORAL-DISTRICT";
 const LEVEL_NI = "NATIONAL-INCREMENTAL";
-const LEVEL_NF = "NATIONAL";
+const LEVEL_N = "NATIONAL";
+const LEVEL_NF = "NATIONAL-FINAL";
 
 function(string electionCode, map<json> result) returns string getFileNameBase =
     electionType == ELECTION_TYPE_PARLIAMENTARY ? getParliamentaryFileNameBase : getPresidentialFileNameBase;
@@ -156,7 +157,7 @@ function getParliamentaryFileNameBase(string electionCode, map<json> result) ret
     match resultLevel {
         LEVEL_PD => { name = name + "PD" + "-" + result.pd_code.toString(); }
         LEVEL_ED => { name = name + "ED" + "-" + result.ed_code.toString(); }
-        LEVEL_NF => { name = name + "N"; }
+        LEVEL_N => { name = name + "N"; }
     }
 
     // add electoral district / polling division names if needed with spaces replaced with _

--- a/subscriber/src/subscriber/save.bal
+++ b/subscriber/src/subscriber/save.bal
@@ -136,11 +136,10 @@ function getPresidentialFileNameBase(string electionCode, map<json> result) retu
 # 	NNN-{TypeCode}-{LevelCode}[-{Code}[--{EDName[--{PDName}]]].{ext}
 # where
 # 	NNN			Sequence number of the result with 0s if needed (001, 002, ..).
-#	{TypeCode}	Result type- "R_V", "R_VI", "R_S", "R_SI", "R_SC", "R_VSN", "R_NC".
+#	{TypeCode}	Result type- "RP_V", "RE_VI", "RE_S", "RN_SI", "RN_VS", "RN_VSN", "RE_SC", "RN_NC", "RN_SCNC".
 #	{LevelCode}	Result level: PD for polling division, ED for electoral district, and N for national.
 #	{Code}      If ED results, then 2 digit code of the district. If PD results then 2 digit ED code followed by one
-#	            character PD code. For Postal, Displaced and Quarantine results, the pd_code will be “PV”, “DV” and
-#	            “QV” respectively.
+#	            character PD code. For Postal and Displaced results, the pd_code will be “PV” and “DV” respectively.
 #	{EDName}	Name of the electoral district in English.
 #	{PDName}	Name of the polling division in English.
 #	{ext}		Either “json” or “xml” depending on the format of the file.

--- a/subscriber/src/subscriber/tests/main_test.bal
+++ b/subscriber/src/subscriber/tests/main_test.bal
@@ -8,17 +8,17 @@ import ballerina/test;
 // Before enabling the test, make sure the aforementioned test is executed and json files exist in the subscriber root
 @test:Config { enable : false }
 function testReceivedDataViaTesDriverFakeElection() {
-    testR_VI("0002-R_VI-ED-01--Colombo.json", 15, 65, 10, 90, 10, 100, 150);
-    testR_VI("0004-R_VI-ED-01--Colombo.json", 105, 100, 35, 240, 30, 270, 350);
-    testR_VI("0006-R_VI-ED-01--Colombo.json", 115, 100, 47, 262, 33, 295, 380);
-    testR_VI("0008-R_VI-ED-02--Gampaha.json", 10, 50, 20, 80, 10, 90, 100);
-    testR_VI("0010-R_VI-ED-02--Gampaha.json", 60, 70, 40, 170, 20, 190, 225);
+    testRE_VI("0002-RE_VI-ED-01--Colombo.json", 15, 65, 10, 90, 10, 100, 150);
+    testRE_VI("0004-RE_VI-ED-01--Colombo.json", 105, 100, 35, 240, 30, 270, 350);
+    testRE_VI("0006-RE_VI-ED-01--Colombo.json", 115, 100, 47, 262, 33, 295, 380);
+    testRE_VI("0008-RE_VI-ED-02--Gampaha.json", 10, 50, 20, 80, 10, 90, 100);
+    testRE_VI("0010-RE_VI-ED-02--Gampaha.json", 60, 70, 40, 170, 20, 190, 225);
 
-    testNational("0012-R_SI-N.json", "Foo", 10, "Bar", 5, "Baz", 3);
-    testNational("0014-R_SI-N.json", "Bar", 25, "Foo", 18, "Baz", 4);
+    testNational("0012-RN_SI-N.json", "Foo", 10, "Bar", 5, "Baz", 3);
+    testNational("0014-RN_SI-N.json", "Bar", 25, "Foo", 18, "Baz", 4);
 
-    testNational("0015-R_VS-N.json", "Foo", 100, "Bar", 75, "Baz", 25);
-    testNational("0016-R_VSN-N.json", "Foo", 100, "Bar", 75, "Baz", 25);
+    testNational("0015-RN_VS-N.json", "Foo", 100, "Bar", 75, "Baz", 25);
+    testNational("0016-RN_VSN-N.json", "Foo", 100, "Bar", 75, "Baz", 25);
 }
 
 function testNational(string filePath, string top, int topCount, string mid, int midCount, string last, int lastCount) {
@@ -40,7 +40,7 @@ function testNational(string filePath, string top, int topCount, string mid, int
 }
 
 
-function testR_VI(string filePath, int fooCount, int barCount, int bazCount, int valid, int rejected, int polled,
+function testRE_VI(string filePath, int fooCount, int barCount, int bazCount, int valid, int rejected, int polled,
         int electors) {
 
     map<json> value = getJson(filePath);

--- a/testdriver/src/testdriver/gen_fake_parliamentary.bal
+++ b/testdriver/src/testdriver/gen_fake_parliamentary.bal
@@ -1,7 +1,7 @@
 function genFakeParliamentary() {
     map<json>[] data = [
         {
-            "type": "R_V",
+            "type": "RP_V",
             "sequence_number": "0101",
             "timestamp": 1420085460.0,
             "level": "POLLING-DIVISION",
@@ -43,7 +43,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_V",
+            "type": "RP_V",
             "sequence_number": "0102",
             "timestamp": 1420086260.0,
             "level": "POLLING-DIVISION",
@@ -85,7 +85,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_V",
+            "type": "RP_V",
             "sequence_number": "0103",
             "timestamp": 1420087260.0,
             "level": "POLLING-DIVISION",
@@ -127,7 +127,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_V",
+            "type": "RP_V",
             "sequence_number": "0107",
             "timestamp": 1420087561.0,
             "level": "POLLING-DIVISION",
@@ -169,7 +169,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_V",
+            "type": "RP_V",
             "sequence_number": "0109",
             "timestamp": 1420087980.0,
             "level": "POLLING-DIVISION",
@@ -211,7 +211,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_S",
+            "type": "RE_S",
             "sequence_number": "0120",
             "timestamp": 1420087983.0,
             "level": "ELECTORAL-DISTRICT",
@@ -243,7 +243,7 @@ function genFakeParliamentary() {
             ]
         },
         {
-            "type": "R_S",
+            "type": "RE_S",
             "sequence_number": "0125",
             "timestamp": 1420087992.0,
             "level": "ELECTORAL-DISTRICT",
@@ -275,7 +275,7 @@ function genFakeParliamentary() {
             ]
         },
         {
-            "type": "R_VS",
+            "type": "RN_VS",
             "sequence_number": "0125",
             "timestamp": 1420087998.0,
             "level": "NATIONAL",
@@ -313,7 +313,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_VSN",
+            "type": "RN_VSN",
             "sequence_number": "0127",
             "timestamp": 1420088001.0,
             "level": "NATIONAL",
@@ -351,7 +351,7 @@ function genFakeParliamentary() {
             }
         },
         {
-            "type": "R_SC",
+            "type": "RE_SC",
             "sequence_number": "0130",
             "timestamp": 1420088002.0,
             "level": "ELECTORAL-DISTRICT",
@@ -373,7 +373,7 @@ function genFakeParliamentary() {
             ]
         },
         {
-            "type": "R_NC",
+            "type": "RN_NC",
             "sequence_number": "0137",
             "timestamp": 142008005.0,
             "level": "NATIONAL",
@@ -387,7 +387,7 @@ function genFakeParliamentary() {
             ]
         },
         {
-            "type": "R_SCNC",
+            "type": "RN_SCNC",
             "sequence_number": "0138",
             "timestamp": 1420088007.0,
             "level": "NATIONAL",

--- a/testdriver/src/testdriver/sendparliamentaryresults.bal
+++ b/testdriver/src/testdriver/sendparliamentaryresults.bal
@@ -4,13 +4,13 @@ import ballerina/io;
 import ballerina/runtime;
 import ballerina/time;
 
-const R_V = "R_V";
-const R_S = "R_S";
-const R_VS = "R_VS";
-const R_VSN = "R_VSN";
-const R_SC = "R_SC";
-const R_NC = "R_NC";
-const R_SCNC = "R_SCNC";
+const RP_V = "RP_V";
+const RE_S = "RE_S";
+const RN_VS = "RN_VS";
+const RN_VSN = "RN_VSN";
+const RE_SC = "RE_SC";
+const RN_NC = "RN_NC";
+const RN_SCNC = "RN_SCNC";
 
 const FINAL = "FINAL";
 
@@ -20,32 +20,32 @@ function sendParliamentaryResults(string electionCode, http:Client rc, map<json>
 
         string resultType = result.'type.toString();
         match resultType {
-            R_V => {
+            RP_V => {
                 check updateByParty(<json[]>result.by_party);
                 check updateSummary(result);
                 check feedResult(rc, electionCode, resultType, result.pd_code.toString(), result);
             }
-            R_S => {
+            RE_S => {
                 check updateByParty(<json[]>result.by_party);
                 check feedResult(rc, electionCode, resultType, result.ed_code.toString(), result);
             }
-            R_VS => {
+            RN_VS => {
                 check updateByParty(<json[]>result.by_party);
                 check updateSummary(result);
                 check feedResult(rc, electionCode, resultType, FINAL, result);
             }
-            R_VSN => {
+            RN_VSN => {
                 check updateByParty(<json[]>result.by_party);
                 check updateSummary(result);
                 check feedResult(rc, electionCode, resultType, FINAL, result);
             }
-            R_SC => {
+            RE_SC => {
                 check feedResult(rc, electionCode, resultType, result.ed_code.toString(), result);
             }
-            R_NC => {
+            RN_NC => {
                 check feedResult(rc, electionCode, resultType, FINAL, result);
             }
-            R_SCNC => {
+            RN_SCNC => {
                 check feedResult(rc, electionCode, resultType, FINAL, result);
             }
         }


### PR DESCRIPTION
This PR

- fixes the image receipt/storage to consider result type too - fixes #150 
- switches to the new result types (which also indicate the level) - fixes #151
- changes config keys to use "distributor" instead of "hub" - fixes #128 
- removes the "Quarantined" check since they are not sent separately
- reverts `LEVEL_NF` to "NATIONAL-FINAL" and introduces `LEVEL_N` for "NATIONAL"